### PR TITLE
feat: A plot point should be created with default skills

### DIFF
--- a/features/skills.feature
+++ b/features/skills.feature
@@ -1,0 +1,38 @@
+Feature: Default Skills
+  As a Game Master
+  I want plot points to be created with default skills
+  So that I don't have to manually add common skills each time
+
+  Background:
+    Given I am logged in as "test_user@example.com" with password "TestPassword123!"
+    And I navigate to the plot point creation page
+
+  Scenario: New plot point includes default skills
+    When I enter plot point name "Test Campaign"
+    Then the plot point should have the following default skills:
+      | name         | attribute | description                                           |
+      | Athletics    | Agility   | Covers running, jumping, swimming, throwing, and catching |
+      | Common Knowledge | Smarts    | General knowledge of the world                           |
+      | Notice       | Smarts    | General awareness and perception                         |
+      | Persuasion   | Spirit    | Ability to convince others                              |
+      | Stealth      | Agility   | The ability to hide and move quietly                    |
+
+  Scenario: Default skills are editable
+    When I enter plot point name "Editable Skills Test"
+    And I edit the "Athletics" skill
+    And I change its attribute to "Strength"
+    And I save the changes
+    Then the "Athletics" skill should have attribute "Strength"
+
+  Scenario: Default skills can be deleted
+    When I enter plot point name "Deletable Skills Test"
+    And I delete the "Stealth" skill
+    And I save the changes
+    Then the plot point should not have a "Stealth" skill
+
+  Scenario: Additional skills can be added to default skills
+    When I enter plot point name "Additional Skills Test"
+    And I add a new skill named "Fighting" with attribute "Agility"
+    And I save the changes
+    Then the plot point should have 6 skills
+    And the plot point should have a "Fighting" skill with attribute "Agility"

--- a/ui-web/features/step_definitions/skills_steps.js
+++ b/ui-web/features/step_definitions/skills_steps.js
@@ -1,0 +1,129 @@
+import '@babel/polyfill'
+import { Given, When, Then } from 'cucumber'
+import { By, until } from 'selenium-webdriver'
+import { expect } from 'chai'
+
+// Navigate to plot point creation page
+Given('I navigate to the plot point creation page', async function() {
+  await this.driver.get(`${this.baseUrl}/plot_point/add`);
+  await this.driver.wait(until.elementLocated(By.id('plotPointName')), 10000);
+});
+
+// Enter plot point name
+When('I enter plot point name {string}', async function(plotPointName) {
+  const nameInput = await this.driver.findElement(By.id('plotPointName'));
+  await nameInput.clear();
+  await nameInput.sendKeys(plotPointName);
+  
+  const descriptionInput = await this.driver.findElement(By.id('plotPointDescription'));
+  await descriptionInput.clear();
+  await descriptionInput.sendKeys('Test plot point with default skills');
+  
+  // Store the plot point name for later reference
+  this.currentPlotPointName = plotPointName;
+});
+
+// Verify default skills exist
+Then('the plot point should have the following default skills:', async function(dataTable) {
+  const expectedSkills = dataTable.hashes();
+  
+  // Navigate to skills section if not already there
+  const skillsSection = await this.driver.findElement(By.id('Skills-undefined'));
+  
+  for (const expectedSkill of expectedSkills) {
+    // Find skill by name
+    const skillElements = await this.driver.findElements(By.xpath(`//input[@value='${expectedSkill.name}']`));
+    expect(skillElements.length).to.be.greaterThan(0, `Skill "${expectedSkill.name}" not found`);
+    
+    // Verify attribute if skill exists
+    if (skillElements.length > 0) {
+      const skillContainer = await skillElements[0].findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+      const attributeSelect = await skillContainer.findElement(By.tagName('select'));
+      const selectedAttribute = await attributeSelect.getAttribute('value');
+      expect(selectedAttribute).to.equal(expectedSkill.attribute, 
+        `Skill "${expectedSkill.name}" has incorrect attribute`);
+    }
+  }
+});
+
+
+// Edit a skill
+When('I edit the {string} skill', async function(skillName) {
+  const skillInput = await this.driver.findElement(By.xpath(`//input[@value='${skillName}']`));
+  this.currentSkillContainer = await skillInput.findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+  this.currentSkillName = skillName;
+});
+
+// Change skill attribute
+When('I change its attribute to {string}', async function(newAttribute) {
+  const attributeSelect = await this.currentSkillContainer.findElement(By.tagName('select'));
+  await attributeSelect.sendKeys(newAttribute);
+});
+
+// Save changes
+When('I save the changes', async function() {
+  const saveButton = await this.driver.findElement(By.xpath('//button[contains(text(), "Save")]'));
+  await saveButton.click();
+  
+  // Wait for save to complete
+  await this.driver.sleep(2000);
+});
+
+// Verify skill attribute
+Then('the {string} skill should have attribute {string}', async function(skillName, expectedAttribute) {
+  const skillInput = await this.driver.findElement(By.xpath(`//input[@value='${skillName}']`));
+  const skillContainer = await skillInput.findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+  const attributeSelect = await skillContainer.findElement(By.tagName('select'));
+  const selectedAttribute = await attributeSelect.getAttribute('value');
+  expect(selectedAttribute).to.equal(expectedAttribute);
+});
+
+// Delete a skill
+When('I delete the {string} skill', async function(skillName) {
+  const skillInput = await this.driver.findElement(By.xpath(`//input[@value='${skillName}']`));
+  const skillContainer = await skillInput.findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+  const deleteButton = await skillContainer.findElement(By.xpath('.//button[contains(text(), "Delete")]'));
+  await deleteButton.click();
+});
+
+// Verify skill doesn't exist
+Then('the plot point should not have a {string} skill', async function(skillName) {
+  const skillElements = await this.driver.findElements(By.xpath(`//input[@value='${skillName}']`));
+  expect(skillElements.length).to.equal(0, `Skill "${skillName}" still exists`);
+});
+
+// Add a new skill
+When('I add a new skill named {string} with attribute {string}', async function(skillName, attribute) {
+  // Find the add skill button
+  const addButton = await this.driver.findElement(By.xpath('//button[contains(text(), "Add") and contains(@id, "Skills")]'));
+  await addButton.click();
+  
+  // Wait for new skill form to appear
+  await this.driver.sleep(1000);
+  
+  // Find the newly added skill input (usually the last one)
+  const skillInputs = await this.driver.findElements(By.id('skillName'));
+  const newSkillInput = skillInputs[skillInputs.length - 1];
+  await newSkillInput.clear();
+  await newSkillInput.sendKeys(skillName);
+  
+  // Set the attribute
+  const skillContainer = await newSkillInput.findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+  const attributeSelect = await skillContainer.findElement(By.tagName('select'));
+  await attributeSelect.sendKeys(attribute);
+});
+
+// Verify skill count
+Then('the plot point should have {int} skills', async function(expectedCount) {
+  const skillInputs = await this.driver.findElements(By.id('skillName'));
+  expect(skillInputs.length).to.equal(expectedCount);
+});
+
+// Verify skill exists with attribute
+Then('the plot point should have a {string} skill with attribute {string}', async function(skillName, expectedAttribute) {
+  const skillInput = await this.driver.findElement(By.xpath(`//input[@value='${skillName}']`));
+  const skillContainer = await skillInput.findElement(By.xpath('./ancestor::div[contains(@class, "BaseEditor")]'));
+  const attributeSelect = await skillContainer.findElement(By.tagName('select'));
+  const selectedAttribute = await attributeSelect.getAttribute('value');
+  expect(selectedAttribute).to.equal(expectedAttribute);
+});

--- a/ui-web/src/models/PlotPoint.js
+++ b/ui-web/src/models/PlotPoint.js
@@ -1,5 +1,6 @@
 import BasicRules from './BasicRules'
 import Powers from './Powers'
+import Skills from './Skills'
 
 export default class PlotPoint {
 	arcaneBackgrounds          = []
@@ -23,7 +24,7 @@ export default class PlotPoint {
 	powers                     = Powers.getDefaultPowers()
 	races                      = []
 	settingRules               = []
-	skills                     = []
+	skills                     = Skills.getDefaultSkills()
 	airVehicles                = []
 	waterVehicles              = []
 	groundVehicles             = []

--- a/ui-web/src/models/PlotPoint.test.js
+++ b/ui-web/src/models/PlotPoint.test.js
@@ -1,0 +1,100 @@
+import PlotPoint from './PlotPoint';
+import Skills from './Skills';
+
+describe('PlotPoint', () => {
+  describe('constructor', () => {
+    it('should initialize with default values', () => {
+      const plotPoint = new PlotPoint();
+      
+      expect(plotPoint.name).toBe('');
+      expect(plotPoint.description).toBe('This is a description');
+      expect(plotPoint.arcaneBackgrounds).toEqual([]);
+      expect(plotPoint.beasts).toEqual([]);
+      expect(plotPoint.characters).toEqual([]);
+      expect(plotPoint.edges).toEqual([]);
+      expect(plotPoint.hindrances).toEqual([]);
+      expect(plotPoint.races).toEqual([]);
+      expect(plotPoint.settingRules).toEqual([]);
+    });
+
+    it('should initialize with default powers', () => {
+      const plotPoint = new PlotPoint();
+      
+      expect(plotPoint.powers).toBeDefined();
+      expect(Array.isArray(plotPoint.powers)).toBe(true);
+      expect(plotPoint.powers.length).toBeGreaterThan(0);
+    });
+
+    it('should initialize with default skills', () => {
+      const plotPoint = new PlotPoint();
+      
+      expect(plotPoint.skills).toBeDefined();
+      expect(Array.isArray(plotPoint.skills)).toBe(true);
+      expect(plotPoint.skills.length).toBeGreaterThan(0);
+      
+      // Verify it contains the expected default skills
+      const skillNames = plotPoint.skills.map(skill => skill.name);
+      expect(skillNames).toContain('Athletics');
+      expect(skillNames).toContain('Common Knowledge');
+      expect(skillNames).toContain('Notice');
+      expect(skillNames).toContain('Persuasion');
+      expect(skillNames).toContain('Stealth');
+    });
+
+    it('should have exactly 5 default skills', () => {
+      const plotPoint = new PlotPoint();
+      expect(plotPoint.skills).toHaveLength(5);
+    });
+
+    it('should have correct attributes for default skills', () => {
+      const plotPoint = new PlotPoint();
+      
+      const athletics = plotPoint.skills.find(s => s.name === 'Athletics');
+      const commonKnowledge = plotPoint.skills.find(s => s.name === 'Common Knowledge');
+      const notice = plotPoint.skills.find(s => s.name === 'Notice');
+      const persuasion = plotPoint.skills.find(s => s.name === 'Persuasion');
+      const stealth = plotPoint.skills.find(s => s.name === 'Stealth');
+      
+      expect(athletics.attribute).toBe('Agility');
+      expect(commonKnowledge.attribute).toBe('Smarts');
+      expect(notice.attribute).toBe('Smarts');
+      expect(persuasion.attribute).toBe('Spirit');
+      expect(stealth.attribute).toBe('Agility');
+    });
+  });
+
+  describe('skills management', () => {
+    it('should allow adding additional skills to the default ones', () => {
+      const plotPoint = new PlotPoint();
+      const initialCount = plotPoint.skills.length;
+      
+      plotPoint.skills.push({
+        name: 'Fighting',
+        attribute: 'Agility',
+        description: 'Hand-to-hand combat'
+      });
+      
+      expect(plotPoint.skills.length).toBe(initialCount + 1);
+      expect(plotPoint.skills[plotPoint.skills.length - 1].name).toBe('Fighting');
+    });
+
+    it('should allow removing skills', () => {
+      const plotPoint = new PlotPoint();
+      const initialCount = plotPoint.skills.length;
+      
+      plotPoint.skills.splice(0, 1); // Remove first skill
+      
+      expect(plotPoint.skills.length).toBe(initialCount - 1);
+    });
+
+    it('should allow modifying existing skills', () => {
+      const plotPoint = new PlotPoint();
+      
+      const athletics = plotPoint.skills.find(s => s.name === 'Athletics');
+      athletics.attribute = 'Strength';
+      
+      const modifiedSkill = plotPoint.skills.find(s => s.name === 'Athletics');
+      expect(modifiedSkill.attribute).toBe('Strength');
+    });
+  });
+});

--- a/ui-web/src/models/Skill.js
+++ b/ui-web/src/models/Skill.js
@@ -1,0 +1,38 @@
+export default class Skill {
+  name = ''
+  attribute = 'Agility'
+  description = ''
+
+  constructor(data = {}) {
+    this.name = data.name || '';
+    this.attribute = data.attribute || 'Agility';
+    this.description = data.description || '';
+  }
+
+  isValidAttribute(attribute) {
+    const validAttributes = ['Agility', 'Smarts', 'Spirit', 'Strength', 'Vigor'];
+    return validAttributes.includes(attribute);
+  }
+
+  updateAttribute(newAttribute) {
+    if (this.isValidAttribute(newAttribute)) {
+      this.attribute = newAttribute;
+    }
+  }
+
+  clone() {
+    return new Skill({
+      name: this.name,
+      attribute: this.attribute,
+      description: this.description
+    });
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      attribute: this.attribute,
+      description: this.description
+    };
+  }
+}

--- a/ui-web/src/models/Skill.test.js
+++ b/ui-web/src/models/Skill.test.js
@@ -1,0 +1,116 @@
+import Skill from './Skill';
+
+describe('Skill', () => {
+  describe('constructor', () => {
+    it('should initialize with default values when no data provided', () => {
+      const skill = new Skill();
+      expect(skill.name).toBe('');
+      expect(skill.attribute).toBe('Agility');
+      expect(skill.description).toBe('');
+    });
+
+    it('should initialize with provided data', () => {
+      const skillData = {
+        name: 'Athletics',
+        attribute: 'Agility',
+        description: 'Covers running, jumping, swimming, throwing, and catching'
+      };
+      
+      const skill = new Skill(skillData);
+      expect(skill.name).toBe('Athletics');
+      expect(skill.attribute).toBe('Agility');
+      expect(skill.description).toBe('Covers running, jumping, swimming, throwing, and catching');
+    });
+
+    it('should use default attribute if not provided', () => {
+      const skill = new Skill({ name: 'Test Skill' });
+      expect(skill.attribute).toBe('Agility');
+    });
+
+    it('should accept all valid attributes', () => {
+      const attributes = ['Agility', 'Smarts', 'Spirit', 'Strength', 'Vigor'];
+      
+      attributes.forEach(attr => {
+        const skill = new Skill({ attribute: attr });
+        expect(skill.attribute).toBe(attr);
+      });
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should return a JSON representation of the skill', () => {
+      const skill = new Skill({
+        name: 'Notice',
+        attribute: 'Smarts',
+        description: 'General awareness and perception'
+      });
+      
+      const json = skill.toJSON();
+      expect(json).toEqual({
+        name: 'Notice',
+        attribute: 'Smarts',
+        description: 'General awareness and perception'
+      });
+    });
+
+    it('should return all properties even with default values', () => {
+      const skill = new Skill();
+      const json = skill.toJSON();
+      
+      expect(json).toHaveProperty('name');
+      expect(json).toHaveProperty('attribute');
+      expect(json).toHaveProperty('description');
+    });
+  });
+
+  describe('validation', () => {
+    it('should validate that attribute is one of the allowed values', () => {
+      const validAttributes = ['Agility', 'Smarts', 'Spirit', 'Strength', 'Vigor'];
+      
+      const skill = new Skill();
+      expect(skill.isValidAttribute('Agility')).toBe(true);
+      expect(skill.isValidAttribute('Invalid')).toBe(false);
+      
+      validAttributes.forEach(attr => {
+        expect(skill.isValidAttribute(attr)).toBe(true);
+      });
+    });
+  });
+
+  describe('updateAttribute', () => {
+    it('should update attribute if valid', () => {
+      const skill = new Skill({ attribute: 'Agility' });
+      
+      skill.updateAttribute('Smarts');
+      expect(skill.attribute).toBe('Smarts');
+    });
+
+    it('should not update attribute if invalid', () => {
+      const skill = new Skill({ attribute: 'Agility' });
+      
+      skill.updateAttribute('InvalidAttribute');
+      expect(skill.attribute).toBe('Agility');
+    });
+  });
+
+  describe('clone', () => {
+    it('should create a deep copy of the skill', () => {
+      const original = new Skill({
+        name: 'Fighting',
+        attribute: 'Agility',
+        description: 'Hand-to-hand combat'
+      });
+      
+      const clone = original.clone();
+      
+      expect(clone).not.toBe(original);
+      expect(clone.name).toBe(original.name);
+      expect(clone.attribute).toBe(original.attribute);
+      expect(clone.description).toBe(original.description);
+      
+      // Verify it's a deep copy
+      clone.name = 'Shooting';
+      expect(original.name).toBe('Fighting');
+    });
+  });
+});

--- a/ui-web/src/models/Skills.js
+++ b/ui-web/src/models/Skills.js
@@ -1,0 +1,71 @@
+import Skill from './Skill';
+
+export default class Skills {
+  skills = []
+
+  constructor(data = {}) {
+    this.skills = data.skills || [];
+  }
+
+  addSkill(skill) {
+    this.skills.push(skill);
+  }
+
+  removeSkill(index) {
+    if (index >= 0 && index < this.skills.length) {
+      this.skills.splice(index, 1);
+    }
+  }
+
+  static getDefaultSkills() {
+    const defaultSkills = [];
+
+    // Athletics
+    const athletics = new Skill({
+      name: 'Athletics',
+      attribute: 'Agility',
+      description: 'Covers running, jumping, swimming, throwing, and catching'
+    });
+    defaultSkills.push(athletics);
+
+    // Common Knowledge
+    const commonKnowledge = new Skill({
+      name: 'Common Knowledge',
+      attribute: 'Smarts',
+      description: 'General knowledge of the world'
+    });
+    defaultSkills.push(commonKnowledge);
+
+    // Notice
+    const notice = new Skill({
+      name: 'Notice',
+      attribute: 'Smarts',
+      description: 'General awareness and perception'
+    });
+    defaultSkills.push(notice);
+
+    // Persuasion
+    const persuasion = new Skill({
+      name: 'Persuasion',
+      attribute: 'Spirit',
+      description: 'Ability to convince others'
+    });
+    defaultSkills.push(persuasion);
+
+    // Stealth
+    const stealth = new Skill({
+      name: 'Stealth',
+      attribute: 'Agility',
+      description: 'The ability to hide and move quietly'
+    });
+    defaultSkills.push(stealth);
+
+    return defaultSkills;
+  }
+
+  toJSON() {
+    return {
+      skills: this.skills.map(s => s.toJSON ? s.toJSON() : s)
+    };
+  }
+}

--- a/ui-web/src/models/Skills.test.js
+++ b/ui-web/src/models/Skills.test.js
@@ -1,0 +1,136 @@
+import Skills from './Skills';
+import Skill from './Skill';
+
+describe('Skills', () => {
+  describe('constructor', () => {
+    it('should initialize with empty skills array by default', () => {
+      const skills = new Skills();
+      expect(skills.skills).toEqual([]);
+    });
+
+    it('should initialize with provided skills data', () => {
+      const skillsData = {
+        skills: [
+          { name: 'Athletics', attribute: 'Agility', description: 'Physical fitness' },
+          { name: 'Notice', attribute: 'Smarts', description: 'Awareness' }
+        ]
+      };
+      const skills = new Skills(skillsData);
+      expect(skills.skills).toHaveLength(2);
+      expect(skills.skills[0].name).toBe('Athletics');
+      expect(skills.skills[1].name).toBe('Notice');
+    });
+  });
+
+  describe('getDefaultSkills', () => {
+    it('should return an array of default skills', () => {
+      const defaultSkills = Skills.getDefaultSkills();
+      expect(Array.isArray(defaultSkills)).toBe(true);
+      expect(defaultSkills.length).toBeGreaterThan(0);
+    });
+
+    it('should include core skills from Savage Worlds', () => {
+      const defaultSkills = Skills.getDefaultSkills();
+      const skillNames = defaultSkills.map(skill => skill.name);
+      
+      expect(skillNames).toContain('Athletics');
+      expect(skillNames).toContain('Common Knowledge');
+      expect(skillNames).toContain('Notice');
+      expect(skillNames).toContain('Persuasion');
+      expect(skillNames).toContain('Stealth');
+    });
+
+    it('should have correct attributes for default skills', () => {
+      const defaultSkills = Skills.getDefaultSkills();
+      const athletics = defaultSkills.find(s => s.name === 'Athletics');
+      const commonKnowledge = defaultSkills.find(s => s.name === 'Common Knowledge');
+      const notice = defaultSkills.find(s => s.name === 'Notice');
+      const persuasion = defaultSkills.find(s => s.name === 'Persuasion');
+      const stealth = defaultSkills.find(s => s.name === 'Stealth');
+      
+      expect(athletics.attribute).toBe('Agility');
+      expect(commonKnowledge.attribute).toBe('Smarts');
+      expect(notice.attribute).toBe('Smarts');
+      expect(persuasion.attribute).toBe('Spirit');
+      expect(stealth.attribute).toBe('Agility');
+    });
+
+    it('should have descriptions for all default skills', () => {
+      const defaultSkills = Skills.getDefaultSkills();
+      defaultSkills.forEach(skill => {
+        expect(skill.description).toBeDefined();
+        expect(skill.description.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should return Skill instances', () => {
+      const defaultSkills = Skills.getDefaultSkills();
+      defaultSkills.forEach(skill => {
+        expect(skill).toBeInstanceOf(Skill);
+      });
+    });
+  });
+
+  describe('addSkill', () => {
+    it('should add a new skill to the skills array', () => {
+      const skills = new Skills();
+      const newSkill = new Skill({
+        name: 'Fighting',
+        attribute: 'Agility',
+        description: 'Hand-to-hand combat'
+      });
+      
+      skills.addSkill(newSkill);
+      expect(skills.skills).toHaveLength(1);
+      expect(skills.skills[0]).toBe(newSkill);
+    });
+  });
+
+  describe('removeSkill', () => {
+    it('should remove a skill at the specified index', () => {
+      const skills = new Skills({
+        skills: [
+          new Skill({ name: 'Athletics', attribute: 'Agility' }),
+          new Skill({ name: 'Notice', attribute: 'Smarts' }),
+          new Skill({ name: 'Stealth', attribute: 'Agility' })
+        ]
+      });
+      
+      skills.removeSkill(1);
+      expect(skills.skills).toHaveLength(2);
+      expect(skills.skills[0].name).toBe('Athletics');
+      expect(skills.skills[1].name).toBe('Stealth');
+    });
+
+    it('should handle removing skill at invalid index gracefully', () => {
+      const skills = new Skills({
+        skills: [
+          new Skill({ name: 'Athletics', attribute: 'Agility' })
+        ]
+      });
+      
+      skills.removeSkill(-1);
+      expect(skills.skills).toHaveLength(1);
+      
+      skills.removeSkill(5);
+      expect(skills.skills).toHaveLength(1);
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should return a JSON representation of the skills', () => {
+      const skills = new Skills({
+        skills: [
+          new Skill({ name: 'Athletics', attribute: 'Agility', description: 'Physical fitness' }),
+          new Skill({ name: 'Notice', attribute: 'Smarts', description: 'Awareness' })
+        ]
+      });
+      
+      const json = skills.toJSON();
+      expect(json.skills).toHaveLength(2);
+      expect(json.skills[0].name).toBe('Athletics');
+      expect(json.skills[0].attribute).toBe('Agility');
+      expect(json.skills[0].description).toBe('Physical fitness');
+    });
+  });
+});


### PR DESCRIPTION
Closes #92

## Issue Summary
A plot point should be created with default skills

## Changes Made
- ✅ Integration tests written (BDD scenarios)
- ✅ Unit tests implemented with proper coverage
- ✅ Feature code implemented following TDD
- ✅ All code follows established patterns

## Implementation Details
- Created new Skill model with name, attribute, and description properties
- Created Skills model with static getDefaultSkills() method
- Modified PlotPoint to initialize with 5 default skills from Savage Worlds core rulebook
- Default skills: Athletics, Common Knowledge, Notice, Persuasion, and Stealth
- Each skill has appropriate attributes and descriptions

## Local Validation Completed
✅ All pipeline validation passed locally
- Unit tests: 29 new tests passing
- Build: Successful
- No new linting errors introduced

## Testing Summary
- ✅ All unit tests executed and passed
- ✅ Test coverage meets requirements
- ✅ Integration tests written and ready

## Pipeline Confidence
All applicable CI/CD pipeline checks have been validated locally before push.

## Review Notes
- Tests written before implementation (TDD followed)
- Code ready for production deployment
- Issue will auto-close when PR is merged